### PR TITLE
[FEAT] : 레디스 서버 장애 대비 예외 처리

### DIFF
--- a/src/main/java/com/example/naver/domain/redisService/LoginRedisService.java
+++ b/src/main/java/com/example/naver/domain/redisService/LoginRedisService.java
@@ -31,28 +31,4 @@ public class LoginRedisService {
     public String findTokenByPid(String prefix, String username) {
         return redisTemplate.opsForValue().get(username + ":" + prefix);
     }
-
-    public void deleteToken(String username) {
-        redisTemplate.executePipelined(new SessionCallback<Void>() {
-            @Override
-            public Void execute(RedisOperations operations) throws DataAccessException {
-                operations.delete(username + ":accessToken");
-                operations.delete(username + ":refreshToken");
-                return null;
-            }
-        });
-    }
-
-    public void initCoupleToken(String myId, String otherId) {
-        redisTemplate.executePipelined(new SessionCallback<Void>() {
-            @Override
-            public Void execute(RedisOperations operations) throws DataAccessException {
-                operations.delete(myId + ":accessToken");
-                operations.delete(myId + ":refreshToken");
-                operations.delete(otherId + ":accessToken");
-                operations.delete(otherId + ":refreshToken");
-                return null;
-            }
-        });
-    }
 }

--- a/src/main/java/com/example/naver/domain/redisService/QueueService.java
+++ b/src/main/java/com/example/naver/domain/redisService/QueueService.java
@@ -75,36 +75,22 @@ public class QueueService {
             for (ZSetOperations.TypedTuple<String> entry : entries) {
                 String messageJson = entry.getValue();
                 Double score = entry.getScore();
+
                 if (messageJson != null && !messageJson.isEmpty()) {
                     MessageQueueRequestDto dto = objectMapper.readValue(messageJson, MessageQueueRequestDto.class);
                     dto.setSequenceNumber(score.longValue());
                     result.add(dto);
                 }
             }
-        }
-        catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
-        } catch (Exception e) {
-            removeMemberQueue(memberId);
-            throw new InfraException(REDIS_GET_ERROR.getCode(), REDIS_GET_ERROR.getErrorMessage());
-        }
-
-        return result;
-    }
-
-    public void removeMemberQueue(Long otherId) {
-        String queueCacheKey = QUEUE_PREFIX + otherId.toString();
-        try {
-            redisTemplateForQueue.delete(queueCacheKey);
         } catch (RedisConnectionFailureException e) {
             throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
         } catch (RedisCommandTimeoutException e) {
             throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
         } catch (Exception e) {
-            throw new InfraException(REDIS_DELETE_ERROR.getCode(), REDIS_DELETE_ERROR.getErrorMessage());
+            throw new InfraException(REDIS_GET_ERROR.getCode(), REDIS_GET_ERROR.getErrorMessage());
         }
+
+        return result;
     }
 
     public void removeMemberQueue(Long memberId, Long lastSequenceNumber) {

--- a/src/main/java/com/example/naver/domain/redisService/story/DeletedStoryCacheService.java
+++ b/src/main/java/com/example/naver/domain/redisService/story/DeletedStoryCacheService.java
@@ -1,6 +1,9 @@
 package com.example.naver.domain.redisService.story;
 
+import com.example.naver.web.exception.infra.InfraException;
+import io.lettuce.core.RedisCommandTimeoutException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializer;
@@ -12,6 +15,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.example.naver.web.exception.ExceptionType.*;
 import static com.example.naver.web.util.Util.DELETED_STORY_CACHE;
 
 @Service
@@ -21,49 +25,79 @@ public class DeletedStoryCacheService {
     private final RedisTemplate<String, Object> redisTemplate;
 
     public Set<Long> getDeletedStory() {
-        Set<Object> storyIds = redisTemplate.opsForSet().members(DELETED_STORY_CACHE);
-        if (storyIds == null) {
-            return new HashSet<>();
+        try {
+            Set<Object> storyIds = redisTemplate.opsForSet().members(DELETED_STORY_CACHE);
+
+            if (storyIds == null) {
+                return new HashSet<>();
+            }
+
+            return storyIds.stream()
+                    .filter(Objects::nonNull)
+                    .map(member -> Long.valueOf(member.toString()))
+                    .collect(Collectors.toSet());
+        } catch (RedisConnectionFailureException e) {
+            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
+        } catch (RedisCommandTimeoutException e) {
+            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (Exception e) {
+            throw new InfraException(REDIS_DELETE_CHECK_ERROR.getCode(), REDIS_DELETE_CHECK_ERROR.getErrorMessage());
         }
-        return storyIds.stream().filter(Objects::nonNull)
-                .map(member -> Long.valueOf(member.toString())).collect(Collectors.toSet());
     }
 
     public boolean isDeleted(Long storyId) {
-        Boolean isDeleted = redisTemplate.opsForSet().isMember(DELETED_STORY_CACHE, storyId);
-        return Boolean.TRUE.equals(isDeleted);
-    }
-
-    public void clearCache() {
-        redisTemplate.delete(DELETED_STORY_CACHE);
+        try {
+            Boolean isDeleted = redisTemplate.opsForSet().isMember(DELETED_STORY_CACHE, storyId);
+            return Boolean.TRUE.equals(isDeleted);
+        } catch (RedisConnectionFailureException e) {
+            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
+        } catch (RedisCommandTimeoutException e) {
+            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (Exception e) {
+            throw new InfraException(REDIS_DELETE_CHECK_ERROR.getCode(), REDIS_DELETE_CHECK_ERROR.getErrorMessage());
+        }
     }
 
     public void removeCache(Set<Long> ids) {
-        redisTemplate.opsForSet().remove(DELETED_STORY_CACHE, ids.toArray());
+        try {
+            redisTemplate.opsForSet().remove(DELETED_STORY_CACHE, ids.toArray());
+        } catch (RedisConnectionFailureException e) {
+            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
+        } catch (RedisCommandTimeoutException e) {
+            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (Exception e) {
+            throw new InfraException(REDIS_DELETE_CACHE_REMOVE_ERROR.getCode(), REDIS_DELETE_CACHE_REMOVE_ERROR.getErrorMessage());
+        }
     }
 
     public Set<Long> findDeleteIntersect(Set<Long> ids) {
         RedisSerializer<String> keySerializer = redisTemplate.getStringSerializer();
+        try {
+            List<Object> results = redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+                for (Long id : ids) {
+                    connection.setCommands().sIsMember(
+                            keySerializer.serialize(DELETED_STORY_CACHE),
+                            keySerializer.serialize(id.toString())
+                    );
+                }
+                return null;
+            });
 
-        List<Object> results = redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            Set<Long> deletedStoryIds = new HashSet<>();
+            int index = 0;
             for (Long id : ids) {
-                connection.setCommands().sIsMember(
-                        keySerializer.serialize(DELETED_STORY_CACHE),
-                        keySerializer.serialize(id.toString())
-                );
+                Boolean isDeleted = (Boolean) results.get(index++);
+                if (Boolean.TRUE.equals(isDeleted)) {
+                    deletedStoryIds.add(id);
+                }
             }
-            return null;
-        });
-
-        Set<Long> deletedStoryIds = new HashSet<>();
-        int index = 0;
-        for (Long id : ids) {
-            Boolean isDeleted = (Boolean) results.get(index++);
-            if (Boolean.TRUE.equals(isDeleted)) {
-                deletedStoryIds.add(id);
-            }
+            return deletedStoryIds;
+        } catch (RedisConnectionFailureException e) {
+            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
+        } catch (RedisCommandTimeoutException e) {
+            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (Exception e) {
+            throw new InfraException(REDIS_DELETE_CHECK_ERROR.getCode(), REDIS_DELETE_CHECK_ERROR.getErrorMessage());
         }
-
-        return deletedStoryIds;
     }
 }

--- a/src/main/java/com/example/naver/domain/redisService/story/StoryCacheService.java
+++ b/src/main/java/com/example/naver/domain/redisService/story/StoryCacheService.java
@@ -3,7 +3,10 @@ package com.example.naver.domain.redisService.story;
 import com.example.naver.domain.dto.MessageQueueRequestDto;
 import com.example.naver.domain.dto.story.res.StoryItemResponseDto;
 import com.example.naver.domain.redisService.QueueService;
+import com.example.naver.web.exception.infra.InfraException;
+import io.lettuce.core.RedisCommandTimeoutException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializer;
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+import static com.example.naver.web.exception.ExceptionType.*;
 import static com.example.naver.web.util.Util.DELETED_STORY_CACHE;
 import static com.example.naver.web.util.Util.UPDATE_STORY_CACHE;
 
@@ -19,37 +23,49 @@ import static com.example.naver.web.util.Util.UPDATE_STORY_CACHE;
 public class StoryCacheService {
 
     private final RedisTemplate<String, Object> redisTemplate;
-    private final QueueService queueService;
 
-    public void update(Long storyId, Long otherId, StoryItemResponseDto data, MessageQueueRequestDto message) {
-        RedisSerializer<String> keySerializer = redisTemplate.getStringSerializer();
-        RedisSerializer<Object> valueSerializer = (RedisSerializer<Object>) redisTemplate.getValueSerializer();
+    public void update(Long storyId, StoryItemResponseDto data) {
+        try {
+            RedisSerializer<String> keySerializer = redisTemplate.getStringSerializer();
+            RedisSerializer<Object> valueSerializer = (RedisSerializer<Object>) redisTemplate.getValueSerializer();
 
-        redisTemplate.executePipelined((RedisCallback<?>) connection -> {
-            connection.hashCommands().hSet(
-                    keySerializer.serialize(UPDATE_STORY_CACHE),
-                    keySerializer.serialize(storyId.toString()),
-                    valueSerializer.serialize(data)
-            );
-            return null;
-        });
-
-        queueService.insert(otherId, message);
+            redisTemplate.executePipelined((RedisCallback<?>) connection -> {
+                connection.multi();
+                connection.hashCommands().hSet(
+                        keySerializer.serialize(UPDATE_STORY_CACHE),
+                        keySerializer.serialize(storyId.toString()),
+                        valueSerializer.serialize(data)
+                );
+                connection.close();
+                return null;
+            });
+        } catch (RedisConnectionFailureException e) {
+            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
+        } catch (RedisCommandTimeoutException e) {
+            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (Exception e) {
+            throw new InfraException(REDIS_WRITE_ERROR.getCode(), REDIS_WRITE_ERROR.getErrorMessage());
+        }
     }
 
-    public void delete(List<Long> storyIds, Long otherId, MessageQueueRequestDto message) {
-        RedisSerializer<String> keySerializer = redisTemplate.getStringSerializer();
-
-        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
-            for (Long storyId : storyIds) {
-                connection.setCommands().sAdd(
-                        keySerializer.serialize(DELETED_STORY_CACHE),
-                        keySerializer.serialize(storyId.toString())
-                );
-            }
-            return null;
-        });
-
-        queueService.insert(otherId, message);
+    public void delete(List<Long> storyIds) {
+        try {
+            RedisSerializer<String> keySerializer = redisTemplate.getStringSerializer();
+            redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+                for (Long storyId : storyIds) {
+                    connection.setCommands().sAdd(
+                            keySerializer.serialize(DELETED_STORY_CACHE),
+                            keySerializer.serialize(storyId.toString())
+                    );
+                }
+                return null;
+            });
+        } catch (RedisConnectionFailureException e) {
+            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
+        } catch (RedisCommandTimeoutException e) {
+            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (Exception e) {
+            throw new InfraException(REDIS_WRITE_ERROR.getCode(), REDIS_WRITE_ERROR.getErrorMessage());
+        }
     }
 }

--- a/src/main/java/com/example/naver/domain/redisService/story/UpdatedStoryCacheService.java
+++ b/src/main/java/com/example/naver/domain/redisService/story/UpdatedStoryCacheService.java
@@ -1,7 +1,10 @@
 package com.example.naver.domain.redisService.story;
 
 import com.example.naver.domain.dto.story.res.StoryItemResponseDto;
+import com.example.naver.web.exception.infra.InfraException;
+import io.lettuce.core.RedisCommandTimeoutException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -11,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.example.naver.web.exception.ExceptionType.*;
 import static com.example.naver.web.util.Util.UPDATE_STORY_CACHE;
 
 @Service
@@ -20,37 +24,56 @@ public class UpdatedStoryCacheService {
     private final RedisTemplate<String, Object> redisTemplate;
 
     public Map<Long, StoryItemResponseDto> getUpdatedStory() {
-        Map<Object, Object> entries = redisTemplate.opsForHash().entries(UPDATE_STORY_CACHE);
-        Map<Long, StoryItemResponseDto> result = new HashMap<>();
-        for (Map.Entry<Object, Object> entry : entries.entrySet()) {
-            Long id = Long.valueOf((String) entry.getKey());
-            StoryItemResponseDto data = (StoryItemResponseDto) entry.getValue();
-            result.put(id, data);
+        try {
+            Map<Object, Object> entries = redisTemplate.opsForHash().entries(UPDATE_STORY_CACHE);
+            Map<Long, StoryItemResponseDto> result = new HashMap<>();
+            for (Map.Entry<Object, Object> entry : entries.entrySet()) {
+                Long id = Long.valueOf((String) entry.getKey());
+                StoryItemResponseDto data = (StoryItemResponseDto) entry.getValue();
+                result.put(id, data);
+            }
+            return result;
+        } catch (RedisConnectionFailureException e) {
+            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
+        } catch (RedisCommandTimeoutException e) {
+            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (Exception e) {
+            throw new InfraException(REDIS_UPDATE_CHECK_ERROR.getCode(), REDIS_UPDATE_CHECK_ERROR.getErrorMessage());
         }
-        return result;
-    }
-
-    public void clearCache() {
-        redisTemplate.delete(UPDATE_STORY_CACHE);
     }
 
     public void removeCache(Set<Long> ids) {
-        redisTemplate.opsForHash().delete(UPDATE_STORY_CACHE, ids.stream().map(Object::toString).toArray());
+        try {
+            redisTemplate.opsForHash().delete(UPDATE_STORY_CACHE, ids.stream().map(Object::toString).toArray());
+        } catch (RedisConnectionFailureException e) {
+            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
+        } catch (RedisCommandTimeoutException e) {
+            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (Exception e) {
+            throw new InfraException(REDIS_UPDATE_CACHE_REMOVE_ERROR.getCode(), REDIS_UPDATE_CACHE_REMOVE_ERROR.getErrorMessage());
+        }
     }
 
     public Map<Long, StoryItemResponseDto> findUpdatedList(List<String> ids) {
-        HashOperations<String, String, StoryItemResponseDto> hashOperations = redisTemplate.opsForHash();
-        List<StoryItemResponseDto> cachedDataList = hashOperations.multiGet(UPDATE_STORY_CACHE, ids);
+        try {
+            HashOperations<String, String, StoryItemResponseDto> hashOps = redisTemplate.opsForHash();
+            List<StoryItemResponseDto> cachedDataList = hashOps.multiGet(UPDATE_STORY_CACHE, ids);
 
-        Map<Long, StoryItemResponseDto> updatedMap = new HashMap<>();
-        for (int i = 0; i < ids.size(); i++) {
-            StoryItemResponseDto cachedData = cachedDataList.get(i);
-            if (cachedData != null) {
-                Long id = Long.valueOf(ids.get(i));
-                updatedMap.put(id, new StoryItemResponseDto(cachedData));
+            Map<Long, StoryItemResponseDto> updatedMap = new HashMap<>();
+            for (int i = 0; i < ids.size(); i++) {
+                StoryItemResponseDto cachedData = cachedDataList.get(i);
+                if (cachedData != null) {
+                    Long id = Long.valueOf(ids.get(i));
+                    updatedMap.put(id, new StoryItemResponseDto(cachedData));
+                }
             }
+            return updatedMap;
+        } catch (RedisConnectionFailureException e) {
+            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
+        } catch (RedisCommandTimeoutException e) {
+            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (Exception e) {
+            throw new InfraException(REDIS_UPDATE_CHECK_ERROR.getCode(), REDIS_UPDATE_CHECK_ERROR.getErrorMessage());
         }
-
-        return updatedMap;
     }
 }

--- a/src/main/java/com/example/naver/domain/service/SlackService.java
+++ b/src/main/java/com/example/naver/domain/service/SlackService.java
@@ -9,10 +9,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 
 import static com.example.naver.web.util.Util.SLACK_WEBHOOK_URL;
 import static com.slack.api.webhook.WebhookPayloads.payload;
@@ -24,7 +21,28 @@ public class SlackService {
     private final Slack slackClient = Slack.getInstance();
 
     @Async
-    public void sendMessage(String title, HashMap<String, String> data) {
+    public void sendBadRequestMessage(HttpServletRequest request, ExceptionType exception) {
+        String title = "🚨 악의적인 요청이 들어왔습니다.";
+        Map<String, String> data = new HashMap<>();
+        data.put("에러 메시지", exception.getErrorMessage());
+        data.put("요청 URI", request.getRequestURI());
+        data.put("요청 IP", request.getRemoteAddr());
+        data.put("Timestamp", new Date().toString());
+        data.put("Request Details", logRequestDetails(request));
+        sendMessage(title, data);
+    }
+
+    @Async
+    public void sendRedisErrorMessage(HttpServletRequest request, ExceptionType exception) {
+        String title = "🛑 Redis Cache Error 발생";
+        Map<String, String> data = new HashMap<>();
+        data.put("에러 코드", String.valueOf(exception.getCode()));
+        data.put("에러 메시지", exception.getErrorMessage());
+        data.put("발생 시각", new Date().toString());
+        sendMessage(title, data);
+    }
+
+    private void sendMessage(String title, Map<String, String> data) {
         try {
             slackClient.send(SLACK_WEBHOOK_URL, payload(p -> p
                     .text(title)
@@ -37,22 +55,6 @@ public class SlackService {
         } catch (IOException e) {
             e.printStackTrace();
         }
-    }
-
-    @Async
-    public void sendMessage(HttpServletRequest request, ExceptionType exception) {
-        String title = "악의적인 요청이 들어왔습니다.";
-        String requestURI = request.getRequestURI();
-        String clientIp = request.getRemoteAddr();
-
-        HashMap<String, String> data = new HashMap<>();
-        data.put("에러 메시지", exception.getErrorMessage());
-        data.put("요청 URI", requestURI);
-        data.put("요청 IP", clientIp);
-        data.put("Timestamp", new Date().toString());
-        data.put("Request Details", logRequestDetails(request));
-
-        sendMessage(title, data);
     }
 
     private String logRequestDetails(HttpServletRequest request) {

--- a/src/main/java/com/example/naver/domain/service/StoryService.java
+++ b/src/main/java/com/example/naver/domain/service/StoryService.java
@@ -209,7 +209,9 @@ public class StoryService {
 
             StoryItemResponseDto data = new StoryItemResponseDto(story, dto);
             MessageQueueRequestDto message = new MessageQueueRequestDto(data, memberId, UPDATE);
-            storyCacheService.update(story.getId(), dto.getOtherId(), data, message);
+
+            storyCacheService.update(story.getId(), data);
+            queueService.insert(dto.getOtherId(), message);
             return data;
         } finally {
             lock.unlock();
@@ -258,7 +260,8 @@ public class StoryService {
             StoryItemResponseDto data = new StoryItemResponseDto(itemList);
             MessageQueueRequestDto message = new MessageQueueRequestDto(itemList.get(0), data, memberId, DELETE);
 
-            storyCacheService.delete(storyIds, otherId, message);
+            storyCacheService.delete(storyIds);
+            queueService.insert(otherId, message);
         } finally {
             lock.unlock();
             coupleLockService.cleanupStoryLock(coupleId, lock);

--- a/src/main/java/com/example/naver/web/exception/ExceptionType.java
+++ b/src/main/java/com/example/naver/web/exception/ExceptionType.java
@@ -91,6 +91,11 @@ public enum ExceptionType {
     REDIS_INSERT_ERROR(60002, "레디스 메시지 삽입 시 오류가 발생했습니다"),
     REDIS_GET_ERROR(60003, "메시지 조회 시 오류가 발생했습니다"),
     REDIS_DELETE_ERROR(60004, "레디스 메시지 삭제 시 오류가 발생했습니다"),
+    REDIS_WRITE_ERROR(60005, "메시지 작성 시 오류가 발생했습니다"),
+    REDIS_DELETE_CHECK_ERROR(60006, "메시지 삭제 체크 시 오류가 발생했습니다"),
+    REDIS_UPDATE_CHECK_ERROR(60007, "메시지 업데이트 체크 시 오류가 발생했습니다"),
+    REDIS_DELETE_CACHE_REMOVE_ERROR(60008, "삭제 캐시 제거 오류가 발생했습니다"),
+    REDIS_UPDATE_CACHE_REMOVE_ERROR(60009, "업데이트 캐시 제거 오류가 발생했습니다"),
 
     /**
      * Event Exception

--- a/src/main/java/com/example/naver/web/filter/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/naver/web/filter/exception/CustomAuthenticationEntryPoint.java
@@ -35,7 +35,12 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
         if (exception != null && Objects.equals(exception.getCode(), BLOCKED_IP.getCode())
                 && serverType.equalsIgnoreCase("prod")) {
-            slackService.sendMessage(request, exception);
+            slackService.sendBadRequestMessage(request, exception);
+        }
+
+        if (exception != null && exception.getCode() >= REDIS_CONNECT_ERROR.getCode() &&
+                exception.getCode() <= REDIS_UPDATE_CACHE_REMOVE_ERROR.getCode()) {
+            slackService.sendRedisErrorMessage(request, exception);
         }
 
         setResponse(response, exception);

--- a/src/main/java/com/example/naver/web/security/CryptoUtil.java
+++ b/src/main/java/com/example/naver/web/security/CryptoUtil.java
@@ -11,6 +11,7 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.util.Base64;
 
+import static com.example.naver.web.exception.ExceptionType.DECRYPT_FAIL;
 import static com.example.naver.web.exception.ExceptionType.ENCRYPT_FAIL;
 
 @Component
@@ -58,7 +59,7 @@ public class CryptoUtil {
             byte[] original = cipher.doFinal(Base64.getDecoder().decode(encrypted));
             return new String(original);
         } catch (Exception ex) {
-            throw new CommonException(ENCRYPT_FAIL.getCode(), ENCRYPT_FAIL.getErrorMessage());
+            throw new CommonException(DECRYPT_FAIL.getCode(), DECRYPT_FAIL.getErrorMessage());
         }
     }
 }


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- [x] 레디스 서버 장애 대비 예외 처리

## 고민과 해결과정
- 로직 체크 과정에서 레디스 서버 장애시 조치 부족을 확인
- 장애 시 슬랙에 전송하며, 추후를 위해 예외 처리 세분화
- 추후 실제 서버 도입 검토