### PR TITLE
[FEAT] 레디서 장애 발생 대비 기능 구현

### DIFF
--- a/src/main/java/com/example/naver/domain/entity/story/Story.java
+++ b/src/main/java/com/example/naver/domain/entity/story/Story.java
@@ -2,6 +2,7 @@ package com.example.naver.domain.entity.story;
 
 import com.example.naver.domain.dto.story.req.StoryCreateListItemRequestDto;
 import com.example.naver.domain.dto.story.req.StoryCreateRequestDto;
+import com.example.naver.domain.dto.story.res.StoryItemResponseDto;
 import com.example.naver.domain.entity.base.BaseEntity;
 import com.example.naver.web.security.EncryptorConverter;
 import jakarta.persistence.*;
@@ -10,7 +11,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.GenericGenerator;
-
 import java.time.LocalDateTime;
 
 import static com.example.naver.web.util.Util.ITEM_CREATED;
@@ -76,5 +76,12 @@ public class Story extends BaseEntity {
         this.location = dto.getLocation();
         this.setCreatedDate(date);
         this.setLastModifiedDate(date);
+    }
+
+    public void updateStory(StoryItemResponseDto data) {
+        this.date = data.getDate();
+        this.memo = data.getMemo();
+        this.location = data.getLocation();
+        this.setLastModifiedDate(LocalDateTime.now());
     }
 }

--- a/src/main/java/com/example/naver/domain/redisService/login/LoginRedisService.java
+++ b/src/main/java/com/example/naver/domain/redisService/login/LoginRedisService.java
@@ -1,4 +1,4 @@
-package com.example.naver.domain.redisService;
+package com.example.naver.domain.redisService.login;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessException;

--- a/src/main/java/com/example/naver/domain/redisService/messageQueue/QueueService.java
+++ b/src/main/java/com/example/naver/domain/redisService/messageQueue/QueueService.java
@@ -1,6 +1,7 @@
-package com.example.naver.domain.redisService;
+package com.example.naver.domain.redisService.messageQueue;
 
 import com.example.naver.domain.dto.MessageQueueRequestDto;
+import com.example.naver.domain.service.SlackService;
 import com.example.naver.web.exception.infra.InfraException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.lettuce.core.RedisCommandTimeoutException;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static com.example.naver.web.exception.ExceptionType.*;
 import static com.example.naver.web.util.Util.QUEUE_PREFIX;
@@ -23,9 +25,17 @@ import static com.example.naver.web.util.Util.QUEUE_SEQ_PREFIX;
 public class QueueService {
 
     private final RedisTemplate<String, String> redisTemplateForQueue;
+    private final SlackService slackService;
     private final ObjectMapper objectMapper;
+    private final Map<Long, List<MessageQueueRequestDto>> localCacheQueue = new ConcurrentHashMap<>();
+    private final long FALLBACK_SEQ = -1L;
 
-    public Long insert(Long memberId, MessageQueueRequestDto message) {
+    /*
+    * 메시지 큐 삽입 메서드
+    * 1. 시퀀스 넘버와 큐의 동시 관리를 위해 LUA SCRIPT 활용해서 삽입
+    * 2. 레디스 연결 싪패를 대비하여, 로컬 캐시를 사용 - 만약 레디스 장애로 인해 삽입 실패시 로컬에 임시 저장을 통해 가용성 확보
+    * */
+    public void insert(Long memberId, MessageQueueRequestDto message) {
         String queueCacheKey = QUEUE_PREFIX + memberId.toString();
         String queueSeqKey = QUEUE_SEQ_PREFIX + memberId;
 
@@ -43,24 +53,26 @@ public class QueueService {
             script.setScriptText(luaScript);
             script.setResultType(Long.class);
 
-
-            Long sequenceNumber = redisTemplateForQueue.execute(
+            redisTemplateForQueue.execute(
                     script,
                     Arrays.asList(queueSeqKey, queueCacheKey),
                     messageJson,
                     String.valueOf(Duration.ofDays(60).getSeconds())
             );
-
-            return sequenceNumber;
-        } catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException e) {
+            message.setSequenceNumber(FALLBACK_SEQ);
+            cacheLocally(memberId, message);
+            slackService.sendRedisErrorMessage(REDIS_CONNECT_ERROR);
         } catch (Exception e) {
             throw new InfraException(REDIS_INSERT_ERROR.getCode(), REDIS_INSERT_ERROR.getErrorMessage());
         }
     }
 
+    /*
+     * 메시지 큐 조회 메서드
+     * 1. 큐에서 메시지 조회하면서 메시지마다 시퀀스 넘버 주입
+     * 2. 만약 로컬 캐시된 데이터가 있다면 같이 조회
+     * */
     public List<MessageQueueRequestDto> getMemberQueue(Long memberId) {
         String queueCacheKey = QUEUE_PREFIX + memberId.toString();
         List<MessageQueueRequestDto> result = new ArrayList<>();
@@ -82,27 +94,51 @@ public class QueueService {
                     result.add(dto);
                 }
             }
-        } catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException e) {
+            slackService.sendRedisErrorMessage(REDIS_CONNECT_ERROR);
         } catch (Exception e) {
             throw new InfraException(REDIS_GET_ERROR.getCode(), REDIS_GET_ERROR.getErrorMessage());
         }
 
+        List<MessageQueueRequestDto> localList = getLocalCache(memberId);
+        result.addAll(localList);
         return result;
     }
 
+    /*
+     * 메시지 큐 삭제 메서드
+     * 1. 큐에서 메시지를 삭제
+     * 2. 만약 가장큰 시퀀스 넘버가 -1L이면, 로컬 캐시에서만 조회하므로 로컬 캐시만 삭제
+     * */
     public void removeMemberQueue(Long memberId, Long lastSequenceNumber) {
+        if (lastSequenceNumber.equals(-1L)) {
+            clearLocalCache(memberId);
+            return;
+        }
+
         String queueCacheKey = QUEUE_PREFIX + memberId.toString();
         try {
             redisTemplateForQueue.opsForZSet().removeRangeByScore(queueCacheKey, 0, lastSequenceNumber);
-        } catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException e) {
+            slackService.sendRedisErrorMessage(REDIS_CONNECT_ERROR);
         } catch (Exception e) {
             throw new InfraException(REDIS_DELETE_ERROR.getCode(), REDIS_DELETE_ERROR.getErrorMessage());
+        } finally {
+            clearLocalCache(memberId);
         }
+    }
+
+    private void cacheLocally(Long memberId, MessageQueueRequestDto message) {
+        localCacheQueue
+                .computeIfAbsent(memberId, id -> Collections.synchronizedList(new ArrayList<>()))
+                .add(message);
+    }
+
+    private List<MessageQueueRequestDto> getLocalCache(Long memberId) {
+        return localCacheQueue.getOrDefault(memberId, Collections.emptyList());
+    }
+
+    private void clearLocalCache(Long memberId) {
+        localCacheQueue.remove(memberId);
     }
 }

--- a/src/main/java/com/example/naver/domain/redisService/story/DeletedStoryCacheService.java
+++ b/src/main/java/com/example/naver/domain/redisService/story/DeletedStoryCacheService.java
@@ -1,5 +1,6 @@
 package com.example.naver.domain.redisService.story;
 
+import com.example.naver.domain.service.SlackService;
 import com.example.naver.web.exception.infra.InfraException;
 import io.lettuce.core.RedisCommandTimeoutException;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,12 @@ import static com.example.naver.web.util.Util.DELETED_STORY_CACHE;
 public class DeletedStoryCacheService {
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final SlackService slackService;
 
+    /*
+     * 벌크 업데이트를 위해 스토리 아이디 셋 조회
+     * 1. 내용 조회 후 벌크 업데이트 진행
+     * */
     public Set<Long> getDeletedStory() {
         try {
             Set<Object> storyIds = redisTemplate.opsForSet().members(DELETED_STORY_CACHE);
@@ -36,40 +42,49 @@ public class DeletedStoryCacheService {
                     .filter(Objects::nonNull)
                     .map(member -> Long.valueOf(member.toString()))
                     .collect(Collectors.toSet());
-        } catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException e) {
+            slackService.sendRedisErrorMessage(REDIS_CONNECT_ERROR);
+            return new HashSet<>();
         } catch (Exception e) {
             throw new InfraException(REDIS_DELETE_CHECK_ERROR.getCode(), REDIS_DELETE_CHECK_ERROR.getErrorMessage());
         }
     }
 
+    /*
+     * 삭제된 스토리 아이디 조회
+     * 1. 스토리 삭제 및 업데이트 전 스토리가 이미 삭제되었는지 체크
+     * */
     public boolean isDeleted(Long storyId) {
         try {
-            Boolean isDeleted = redisTemplate.opsForSet().isMember(DELETED_STORY_CACHE, storyId);
-            return Boolean.TRUE.equals(isDeleted);
-        } catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+            Boolean inRedis = redisTemplate.opsForSet().isMember(DELETED_STORY_CACHE, storyId);
+            return Boolean.TRUE.equals(inRedis);
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException e) {
+            slackService.sendRedisErrorMessage(REDIS_CONNECT_ERROR);
+            return false;
         } catch (Exception e) {
             throw new InfraException(REDIS_DELETE_CHECK_ERROR.getCode(), REDIS_DELETE_CHECK_ERROR.getErrorMessage());
         }
     }
 
+    /*
+     * 삭제 후 캐시 삭제
+     * 1. 벌크 업데이트 후 스토리 캐시를 삭제
+     * */
     public void removeCache(Set<Long> ids) {
         try {
             redisTemplate.opsForSet().remove(DELETED_STORY_CACHE, ids.toArray());
-        } catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException e) {
+            slackService.sendRedisErrorMessage(REDIS_CONNECT_ERROR);
         } catch (Exception e) {
             throw new InfraException(REDIS_DELETE_CACHE_REMOVE_ERROR.getCode(), REDIS_DELETE_CACHE_REMOVE_ERROR.getErrorMessage());
         }
     }
 
+    /*
+     * 삭제 체크 메서드
+     * 1. 스토리가 삭제되었는지 체크하는 메서드
+     * 2. DB에서 데이터 조회했을때 해당 아이디들에 대해서 삭제 반영
+     * */
     public Set<Long> findDeleteIntersect(Set<Long> ids) {
         RedisSerializer<String> keySerializer = redisTemplate.getStringSerializer();
         try {
@@ -91,11 +106,11 @@ public class DeletedStoryCacheService {
                     deletedStoryIds.add(id);
                 }
             }
+
             return deletedStoryIds;
-        } catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException e) {
+            slackService.sendRedisErrorMessage(REDIS_CONNECT_ERROR);
+            return new HashSet<>();
         } catch (Exception e) {
             throw new InfraException(REDIS_DELETE_CHECK_ERROR.getCode(), REDIS_DELETE_CHECK_ERROR.getErrorMessage());
         }

--- a/src/main/java/com/example/naver/domain/redisService/story/StoryCacheService.java
+++ b/src/main/java/com/example/naver/domain/redisService/story/StoryCacheService.java
@@ -1,8 +1,6 @@
 package com.example.naver.domain.redisService.story;
 
-import com.example.naver.domain.dto.MessageQueueRequestDto;
 import com.example.naver.domain.dto.story.res.StoryItemResponseDto;
-import com.example.naver.domain.redisService.QueueService;
 import com.example.naver.web.exception.infra.InfraException;
 import io.lettuce.core.RedisCommandTimeoutException;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/naver/domain/redisService/story/StoryCacheService.java
+++ b/src/main/java/com/example/naver/domain/redisService/story/StoryCacheService.java
@@ -1,6 +1,10 @@
 package com.example.naver.domain.redisService.story;
 
 import com.example.naver.domain.dto.story.res.StoryItemResponseDto;
+import com.example.naver.domain.entity.story.Story;
+import com.example.naver.domain.repository.StoryRepository;
+import com.example.naver.domain.service.SlackService;
+import com.example.naver.domain.service.StoryService;
 import com.example.naver.web.exception.infra.InfraException;
 import io.lettuce.core.RedisCommandTimeoutException;
 import lombok.RequiredArgsConstructor;
@@ -9,7 +13,9 @@ import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.example.naver.web.exception.ExceptionType.*;
@@ -18,34 +24,44 @@ import static com.example.naver.web.util.Util.UPDATE_STORY_CACHE;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class StoryCacheService {
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final SlackService slackService;
+    private final StoryRepository storyRepository;
 
-    public void update(Long storyId, StoryItemResponseDto data) {
+    /*
+     * 벌크 업데이트를 위해 스토리 업데이트 데이터 생성
+     * 1. 데이터 레디스에 저장 - 추후 벌크 업데이트로 활용
+     * 2. 만약 저장이 안될 시 이를 바로 데이터베이스에 반영
+     * */
+    public void update(Story story, StoryItemResponseDto data) {
         try {
             RedisSerializer<String> keySerializer = redisTemplate.getStringSerializer();
             RedisSerializer<Object> valueSerializer = (RedisSerializer<Object>) redisTemplate.getValueSerializer();
 
             redisTemplate.executePipelined((RedisCallback<?>) connection -> {
-                connection.multi();
                 connection.hashCommands().hSet(
                         keySerializer.serialize(UPDATE_STORY_CACHE),
-                        keySerializer.serialize(storyId.toString()),
+                        keySerializer.serialize(story.getId().toString()),
                         valueSerializer.serialize(data)
                 );
-                connection.close();
                 return null;
             });
-        } catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException e) {
+            story.updateStory(data);
+            slackService.sendRedisErrorMessage(REDIS_CONNECT_ERROR);
         } catch (Exception e) {
             throw new InfraException(REDIS_WRITE_ERROR.getCode(), REDIS_WRITE_ERROR.getErrorMessage());
         }
     }
 
+    /*
+     * 벌크 업데이트를 위해 스토리 삭제 데이터 생성
+     * 1. 데이터 레디스에 저장 - 추후 벌크 업데이트로 활용
+     * 2. 만약 저장이 안될 시 이를 바로 데이터베이스에 반영
+     * */
     public void delete(List<Long> storyIds) {
         try {
             RedisSerializer<String> keySerializer = redisTemplate.getStringSerializer();
@@ -58,10 +74,9 @@ public class StoryCacheService {
                 }
                 return null;
             });
-        } catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException e) {
+            storyRepository.bulkUpdateStatusToFalse(storyIds);
+            slackService.sendRedisErrorMessage(REDIS_CONNECT_ERROR);
         } catch (Exception e) {
             throw new InfraException(REDIS_WRITE_ERROR.getCode(), REDIS_WRITE_ERROR.getErrorMessage());
         }

--- a/src/main/java/com/example/naver/domain/redisService/story/UpdatedStoryCacheService.java
+++ b/src/main/java/com/example/naver/domain/redisService/story/UpdatedStoryCacheService.java
@@ -1,6 +1,7 @@
 package com.example.naver.domain.redisService.story;
 
 import com.example.naver.domain.dto.story.res.StoryItemResponseDto;
+import com.example.naver.domain.service.SlackService;
 import com.example.naver.web.exception.infra.InfraException;
 import io.lettuce.core.RedisCommandTimeoutException;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +23,12 @@ import static com.example.naver.web.util.Util.UPDATE_STORY_CACHE;
 public class UpdatedStoryCacheService {
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final SlackService slackService;
 
+    /*
+     * 벌크 업데이트를 위해 스토리 해시 조회
+     * 1. 내용 조회 후 벌크 업데이트 진행
+     * */
     public Map<Long, StoryItemResponseDto> getUpdatedStory() {
         try {
             Map<Object, Object> entries = redisTemplate.opsForHash().entries(UPDATE_STORY_CACHE);
@@ -32,46 +38,53 @@ public class UpdatedStoryCacheService {
                 StoryItemResponseDto data = (StoryItemResponseDto) entry.getValue();
                 result.put(id, data);
             }
+
             return result;
-        } catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException e) {
+            slackService.sendRedisErrorMessage(REDIS_CONNECT_ERROR);
+            return new HashMap<>();
         } catch (Exception e) {
             throw new InfraException(REDIS_UPDATE_CHECK_ERROR.getCode(), REDIS_UPDATE_CHECK_ERROR.getErrorMessage());
         }
     }
 
+    /*
+     * 삭제 후 캐시 삭제
+     * 1. 벌크 업데이트 후 스토리 캐시를 삭제
+     * */
     public void removeCache(Set<Long> ids) {
         try {
             redisTemplate.opsForHash().delete(UPDATE_STORY_CACHE, ids.stream().map(Object::toString).toArray());
-        } catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException e) {
+            slackService.sendRedisErrorMessage(REDIS_CONNECT_ERROR);
         } catch (Exception e) {
             throw new InfraException(REDIS_UPDATE_CACHE_REMOVE_ERROR.getCode(), REDIS_UPDATE_CACHE_REMOVE_ERROR.getErrorMessage());
         }
     }
 
+    /*
+     * 업데이트 체크 메서드
+     * 1. 스토리가 업데이트 되었는지 체크하는 메서드
+     * 2. DB에서 데이터 조회했을때 해당 아이디들에 대해서 업데이트 반영
+     * */
     public Map<Long, StoryItemResponseDto> findUpdatedList(List<String> ids) {
         try {
             HashOperations<String, String, StoryItemResponseDto> hashOps = redisTemplate.opsForHash();
             List<StoryItemResponseDto> cachedDataList = hashOps.multiGet(UPDATE_STORY_CACHE, ids);
 
-            Map<Long, StoryItemResponseDto> updatedMap = new HashMap<>();
+            Map<Long, StoryItemResponseDto> result = new HashMap<>();
             for (int i = 0; i < ids.size(); i++) {
                 StoryItemResponseDto cachedData = cachedDataList.get(i);
                 if (cachedData != null) {
                     Long id = Long.valueOf(ids.get(i));
-                    updatedMap.put(id, new StoryItemResponseDto(cachedData));
+                    result.put(id, new StoryItemResponseDto(cachedData));
                 }
             }
-            return updatedMap;
-        } catch (RedisConnectionFailureException e) {
-            throw new InfraException(REDIS_CONNECT_ERROR.getCode(), REDIS_CONNECT_ERROR.getErrorMessage());
-        } catch (RedisCommandTimeoutException e) {
-            throw new InfraException(REDIS_TIMEOUT_ERROR.getCode(), REDIS_TIMEOUT_ERROR.getErrorMessage());
+
+            return result;
+        } catch (RedisConnectionFailureException | RedisCommandTimeoutException e) {
+            slackService.sendRedisErrorMessage(REDIS_CONNECT_ERROR);
+            return new HashMap<>();
         } catch (Exception e) {
             throw new InfraException(REDIS_UPDATE_CHECK_ERROR.getCode(), REDIS_UPDATE_CHECK_ERROR.getErrorMessage());
         }

--- a/src/main/java/com/example/naver/domain/service/LoginService.java
+++ b/src/main/java/com/example/naver/domain/service/LoginService.java
@@ -2,7 +2,7 @@ package com.example.naver.domain.service;
 
 import com.example.naver.domain.dto.member.res.TokenResponseDto;
 import com.example.naver.domain.entity.member.Member;
-import com.example.naver.domain.redisService.LoginRedisService;
+import com.example.naver.domain.redisService.login.LoginRedisService;
 import com.example.naver.web.exception.member.MemberException;
 import com.example.naver.web.filter.apple.ApplePublicKeyGenerator;
 import com.example.naver.web.filter.apple.ApplePublicKeyResponse;

--- a/src/main/java/com/example/naver/domain/service/SlackService.java
+++ b/src/main/java/com/example/naver/domain/service/SlackService.java
@@ -33,7 +33,7 @@ public class SlackService {
     }
 
     @Async
-    public void sendRedisErrorMessage(HttpServletRequest request, ExceptionType exception) {
+    public void sendRedisErrorMessage(ExceptionType exception) {
         String title = "🛑 Redis Cache Error 발생";
         Map<String, String> data = new HashMap<>();
         data.put("에러 코드", String.valueOf(exception.getCode()));

--- a/src/main/java/com/example/naver/domain/service/StoryService.java
+++ b/src/main/java/com/example/naver/domain/service/StoryService.java
@@ -11,7 +11,7 @@ import com.example.naver.domain.entity.member.Couple;
 import com.example.naver.domain.entity.member.Member;
 import com.example.naver.domain.entity.story.Story;
 import com.example.naver.domain.generator.StoryIDGenerator;
-import com.example.naver.domain.redisService.QueueService;
+import com.example.naver.domain.redisService.messageQueue.QueueService;
 import com.example.naver.domain.redisService.story.DeletedStoryCacheService;
 import com.example.naver.domain.redisService.story.StoryCacheService;
 import com.example.naver.domain.redisService.story.UpdatedStoryCacheService;

--- a/src/main/java/com/example/naver/domain/service/StoryService.java
+++ b/src/main/java/com/example/naver/domain/service/StoryService.java
@@ -210,7 +210,7 @@ public class StoryService {
             StoryItemResponseDto data = new StoryItemResponseDto(story, dto);
             MessageQueueRequestDto message = new MessageQueueRequestDto(data, memberId, UPDATE);
 
-            storyCacheService.update(story.getId(), data);
+            storyCacheService.update(story, data);
             queueService.insert(dto.getOtherId(), message);
             return data;
         } finally {

--- a/src/main/java/com/example/naver/web/controller/CoupleController.java
+++ b/src/main/java/com/example/naver/web/controller/CoupleController.java
@@ -2,7 +2,7 @@ package com.example.naver.web.controller;
 
 import com.example.naver.domain.dto.AckRequestDto;
 import com.example.naver.domain.dto.MessageQueueRequestDto;
-import com.example.naver.domain.redisService.QueueService;
+import com.example.naver.domain.redisService.messageQueue.QueueService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/example/naver/web/filter/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/naver/web/filter/exception/CustomAuthenticationEntryPoint.java
@@ -38,11 +38,6 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
             slackService.sendBadRequestMessage(request, exception);
         }
 
-        if (exception != null && exception.getCode() >= REDIS_CONNECT_ERROR.getCode() &&
-                exception.getCode() <= REDIS_UPDATE_CACHE_REMOVE_ERROR.getCode()) {
-            slackService.sendRedisErrorMessage(request, exception);
-        }
-
         setResponse(response, exception);
     }
 


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- [x] 레디스 장애 발생 대비, 로컬 메시지 큐로 대체
- [x] 레디스 장애 발생 대비, 데이터베이스 선반영

## 고민과 해결과정
- 레디스 장애 발생 대비 기능 구현이 미흡하였다.
- 메시지 큐는 로컬 메시지 큐를 활용하도록 개선
- 벌크 업데이트를 위한 데이터는 미리 데이터 베이스에 선반영하게 하여 데이터 불일치 문제 해결