### PR TITLE
[FEAT] 레디스 메모리 성능 개선

### DIFF
--- a/src/main/java/com/example/naver/domain/redis/login/LoginRedisService.java
+++ b/src/main/java/com/example/naver/domain/redis/login/LoginRedisService.java
@@ -14,10 +14,10 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class LoginRedisService {
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<String, String> stringTemplate;
 
     public void saveToken(String username, String accessToken, String refreshToken) {
-        redisTemplate.executePipelined(new SessionCallback<Void>() {
+        stringTemplate.executePipelined(new SessionCallback<Void>() {
             @Override
             public Void execute(RedisOperations operations) throws DataAccessException {
                 ValueOperations<String, String> valueOps = operations.opsForValue();
@@ -29,6 +29,6 @@ public class LoginRedisService {
     }
 
     public String findTokenByPid(String prefix, String username) {
-        return redisTemplate.opsForValue().get(username + ":" + prefix);
+        return stringTemplate.opsForValue().get(username + ":" + prefix);
     }
 }

--- a/src/main/java/com/example/naver/domain/redis/queue/QueueService.java
+++ b/src/main/java/com/example/naver/domain/redis/queue/QueueService.java
@@ -25,7 +25,7 @@ import static com.example.naver.web.util.Util.QUEUE_SEQ_PREFIX;
 @RequiredArgsConstructor
 public class QueueService {
 
-    private final RedisTemplate<String, String> redisTemplateForQueue;
+    private final RedisTemplate<String, String> stringTemplate;
     private final SlackService slackService;
     private final ObjectMapper objectMapper;
 
@@ -68,7 +68,7 @@ public class QueueService {
 
     private void executeInsert(String seqKey, String queueKey, String msgJson) {
         DefaultRedisScript<Long> script = new DefaultRedisScript<>(INSERT_LUA, Long.class);
-        redisTemplateForQueue.execute(
+        stringTemplate.execute(
                 script,
                 Arrays.asList(seqKey, queueKey),
                 msgJson,
@@ -111,7 +111,7 @@ public class QueueService {
         List<MessageQueueRequestDto> result = new ArrayList<>();
 
         Set<ZSetOperations.TypedTuple<String>> entries =
-                redisTemplateForQueue.opsForZSet().rangeWithScores(queueKey, 0, -1);
+                stringTemplate.opsForZSet().rangeWithScores(queueKey, 0, -1);
 
         if (entries.isEmpty()) {
             return Collections.emptyList();
@@ -161,7 +161,7 @@ public class QueueService {
 
     private void executeDelete(Long memberId, Long lastSequence) {
         String queueKey = QUEUE_PREFIX + memberId;
-        redisTemplateForQueue.opsForZSet().removeRangeByScore(queueKey, 0, lastSequence);
+        stringTemplate.opsForZSet().removeRangeByScore(queueKey, 0, lastSequence);
     }
 
 

--- a/src/main/java/com/example/naver/domain/redis/story/UpdatedStoryCacheService.java
+++ b/src/main/java/com/example/naver/domain/redis/story/UpdatedStoryCacheService.java
@@ -22,7 +22,7 @@ import static com.example.naver.web.util.Util.UPDATE_STORY_CACHE;
 @RequiredArgsConstructor
 public class UpdatedStoryCacheService {
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, Object> objectTemplate;
     private final SlackService slackService;
 
     /*
@@ -30,7 +30,7 @@ public class UpdatedStoryCacheService {
      * */
     public Map<Long, StoryItemResponseDto> getUpdatedStory() {
         try {
-            Map<Object, Object> entries = redisTemplate.opsForHash()
+            Map<Object, Object> entries = objectTemplate.opsForHash()
                     .entries(UPDATE_STORY_CACHE);
 
             Map<Long, StoryItemResponseDto> result = new HashMap<>();
@@ -59,7 +59,7 @@ public class UpdatedStoryCacheService {
      * */
     public void removeCache(Set<Long> ids) {
         try {
-            redisTemplate.opsForHash()
+            objectTemplate.opsForHash()
                     .delete(UPDATE_STORY_CACHE,
                             ids.stream()
                                     .map(Object::toString)
@@ -84,7 +84,7 @@ public class UpdatedStoryCacheService {
     public Map<Long, StoryItemResponseDto> findUpdatedList(List<String> ids) {
         try {
             HashOperations<String, String, StoryItemResponseDto> hashOps =
-                    redisTemplate.opsForHash();
+                    objectTemplate.opsForHash();
 
             List<StoryItemResponseDto> cachedList =
                     hashOps.multiGet(UPDATE_STORY_CACHE, ids);

--- a/src/main/java/com/example/naver/domain/service/StoryService.java
+++ b/src/main/java/com/example/naver/domain/service/StoryService.java
@@ -320,7 +320,7 @@ public class StoryService {
     }
 
     /* 벌크 업데이트 */
-    @Scheduled(fixedRate = TEM_MINUTE)
+    @Scheduled(fixedRate = ONE_MINUTE)
     public void syncStoryToDatabase() {
         bulkUpdateStoryAsync();
         bulkUpdateDeleteStoryAsync();

--- a/src/main/java/com/example/naver/web/config/RedisConfig.java
+++ b/src/main/java/com/example/naver/web/config/RedisConfig.java
@@ -17,28 +17,42 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
+    public RedisTemplate<String, Object> objectTemplate(
+            RedisConnectionFactory connectionFactory
+    ) {
+        RedisTemplate<String, Object> template =
+                new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
 
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setHashKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        StringRedisSerializer stringSerializer =
+                new StringRedisSerializer();
+        GenericJackson2JsonRedisSerializer JsonSerializer =
+                new GenericJackson2JsonRedisSerializer();
+
+        template.setKeySerializer(stringSerializer);
+        template.setHashKeySerializer(stringSerializer);
+        template.setValueSerializer(JsonSerializer);
+        template.setHashValueSerializer(JsonSerializer);
 
         return template;
     }
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplateForQueue(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
+    public RedisTemplate<String, String> stringTemplate(
+            RedisConnectionFactory connectionFactory
+    ) {
+        RedisTemplate<String, String> template =
+                new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
 
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setHashKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new StringRedisSerializer());
-        template.setHashValueSerializer(new StringRedisSerializer());
-        template.setDefaultSerializer(new StringRedisSerializer());
+        StringRedisSerializer serializer =
+                new StringRedisSerializer();
+
+        template.setKeySerializer(serializer);
+        template.setHashKeySerializer(serializer);
+        template.setValueSerializer(serializer);
+        template.setHashValueSerializer(serializer);
+        template.setDefaultSerializer(serializer);
 
         return template;
     }

--- a/src/main/java/com/example/naver/web/util/Util.java
+++ b/src/main/java/com/example/naver/web/util/Util.java
@@ -48,6 +48,8 @@ public class Util {
 
     /*시간*/
     public static final long EPOCH = 1721865600000L;
+    public static final long HALF_MINUTE = 30 * 1000;
+    public static final long ONE_MINUTE = 60 * 1000;
     public static final long TEM_MINUTE = 10 * 60 * 1000;
     public static final long ONE_HOUR = 60 * 60 * 1000;
     public static final long ONE_DAY = 24 * 60 * 60 * 1000;


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- 파이프라인에서 발생하는 메모리 오버해드 대체
- 메모리 효율을 위해 SET의 직렬화기를 문자열 템플릿 변경

## 고민과 해결과정

### 1️⃣ 왜 SET의 직렬화기를 바꾸었을까?
지금껏 나는 2개의 직렬화기를 썼다. 
stringTemplate은 ZSET 용이고, objectTemplate은 해시랑 SET 용도였다.
```java
@Bean
public RedisTemplate<String, String> stringTemplate(
        RedisConnectionFactory connectionFactory
) {
    RedisTemplate<String, String> template =
            new RedisTemplate<>();
    template.setConnectionFactory(connectionFactory);

    StringRedisSerializer serializer =
            new StringRedisSerializer();

    template.setKeySerializer(serializer);
    template.setHashKeySerializer(serializer);
    template.setValueSerializer(serializer);
    template.setHashValueSerializer(serializer);
    template.setDefaultSerializer(serializer);

    return template;
} 
```
```java
@Bean
public RedisTemplate<String, Object> objectTemplate(
        RedisConnectionFactory connectionFactory
) {
    RedisTemplate<String, Object> template =
            new RedisTemplate<>();
    template.setConnectionFactory(connectionFactory);

    StringRedisSerializer stringSerializer =
            new StringRedisSerializer();
    GenericJackson2JsonRedisSerializer JsonSerializer =
            new GenericJackson2JsonRedisSerializer();

    template.setKeySerializer(stringSerializer);
    template.setHashKeySerializer(stringSerializer);
    template.setValueSerializer(JsonSerializer);
    template.setHashValueSerializer(JsonSerializer);

    return template;
}
```
GenericJackson2JsonRedisSerializer는 클래스의 메타 정보를 포함하는 메모리 비효율을 가진다.
하자만 SET의 경우, 문자열로 저장한다. 이는 object 직렬화기보다 string 직렬화기가 더 적합하다는 것을 의미한다.
즉, SET 직렬화기로 GenericJackson2JsonRedisSerializer를 사용하면서 굳이 메모리를 낭비할 필요가 없다.


### 2️⃣ 왜 파이프라인 코드를 제거했을까?
레디스 파이프라인은 여러 요청을 네트워크 왕복 한 번으로 처리한다.
따라서 성능 측면에서 매우 효율적이다. 
그러나 파이프라인 방식에도 몇 가지 단점이 존재한다.

먼저, 파이프라인을 사용할 때 요청은 묶여서 전송은 된다.
하지만 Redis 서버 측에서는 개별 요청으로 각각 처리된다. 
이로 인해 각 요청을 별도로 파싱하고 실행하는 과정에서 커맨드별 오버헤드가 발생한다. 
또한 Redis 서버가 모든 응답을 메모리에 버퍼링하여 한 번에 전송한다.
이는 응답 데이터가 많아질 경우 메모리 부담이 증가할 수 있다.

반면, 다음과 같은 방식으로 요청을 통합하면 파이프라인의 장점을 유지하면서 단점을 극복할 수 있다
```java
String[] members = storyIds.stream()
          .map(String::valueOf)
          .toArray(String[]::new);

stringTemplate.opsForSet()
        .add(DELETED_STORY_CACHE, members);
```
이 방식은 Redis에 단 하나의 요청으로 전달되어, 개별 명령 처리로 인한 오버헤드를 최소화한다.
또한 요청이 단 1개로만 인식이 되어 오버헤드도 감소하고 응답시도 단일적으로 처리된다.